### PR TITLE
Updating LinkedIn link

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@
 
     * [**Drop a Mail**](mailto:raghavkhullar16@gmail.com)
 
-    * [**Connect via LinkedIn**](www.linkedin.com/in/raghav-khullar)
+    * [**Connect via LinkedIn**](https://www.linkedin.com/in/raghav-khullar/)
 
     * [**Visit my Website**](https://raghavk16.github.io/)
     


### PR DESCRIPTION
Hello Sir! Your LinkedIn link was redirecting to https://github.com/RaghavK16/RaghavK16/blob/master/www.linkedin.com/in/raghav-khullar, I think that adding https:// before the link should do the thing ;) Cheers! Btw Great profile readme!